### PR TITLE
Add compatibility for TYPO3 9.5 LTS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,14 @@
     "description": "",
     "type": "typo3-cms-extension",
     "require": {
-        "typo3/cms-core": "^8.7",
-        "typo3/cms-form": "^8.7"
+        "typo3/cms-core": "^8.7 || ^9.5",
+        "typo3/cms-form": "^8.7 || ^9.5"
     },
     "replace": {
         "form_element_linked_checkbox": "self.version",
         "tritum/form_element_linked_checkbox": "self.version"
     },
-    "license": "GPL-2.0+",
+    "license": "GPL-2.0-or-later",
     "authors": [
         {
             "name": "Björn Jacob TRITUM GmbH",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF['form_element_linked_checkbox'] = [
     'version' => '1.0.4',
     'constraints' => [
         'depends' => [
-            'typo3' => '8.7.0-9.5.0',
+            'typo3' => '8.7.0-9.5.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
Thank you for this great extension!

As it is currently full compatible with TYPO3 9.5 LTS (theoretically), I adapted the requirements in order to be able to add official support for it. From my perspective, there are no necessary code changes in order to support both TYPO3 8.7 and 9.5 versions.