### PR TITLE
[FEATURE] Allow character substitution for link text in label

### DIFF
--- a/Classes/Hooks/FormElementLinkResolverHook.php
+++ b/Classes/Hooks/FormElementLinkResolverHook.php
@@ -1,0 +1,177 @@
+<?php
+declare(strict_types=1);
+namespace TRITUM\FormElementLinkedCheckbox\Hooks;
+
+/*
+ * This file is part of the TYPO3 CMS extension "form_element_linked_checkbox".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Form\Domain\Model\FormElements\GenericFormElement;
+use TYPO3\CMS\Form\Domain\Model\Renderable\RootRenderableInterface;
+use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
+use TYPO3\CMS\Form\Service\TranslationService;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+/**
+ * Form rendering hook to resolve link in label of LinkedCheckbox elements.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+class FormElementLinkResolverHook
+{
+    /**
+     * @var string Form element type to match
+     */
+    protected $type = 'LinkedCheckbox';
+
+    /**
+     * Resolve link in label of form elements with type LinkedCheckbox.
+     *
+     * @param FormRuntime $formRuntime
+     * @param RootRenderableInterface $renderable
+     */
+    public function beforeRendering(FormRuntime $formRuntime, RootRenderableInterface $renderable)
+    {
+        $label = $this->translate($renderable, 'label', $formRuntime);
+
+        // Only process linkText parsing if $renderable matches given type
+        // and form element label contains any argument flags such as %s.
+        // This also checks if one tries to use the percent sign as regular
+        // character instead of a flag marked for inserting the translated
+        // linkText. It needs to be set as double-percent (%%) substring.
+        if (
+            !$renderable instanceof GenericFormElement ||
+            $renderable->getType() !== $this->type ||
+            !self::needsCharacterSubstitution($label)
+        ) {
+            return;
+        }
+
+        $properties = $renderable->getProperties();
+        $pageUid = (int) $properties['pageUid'];
+        $translatedLinkText = $this->translate($renderable, 'linkText', $formRuntime);
+
+        // Build link if pageUid is valid
+        if ($pageUid) {
+            $additionalLinkConfiguration = $renderable->getRenderingOptions()['linkConfiguration'] ?? [];
+            $content = $this->buildLinkFromPageUid($translatedLinkText, $pageUid, $additionalLinkConfiguration);
+        } else {
+            $content = $properties['linkText'];
+        }
+
+        // Provide translated link as argument for the form element label
+        $renderable->setRenderingOption('translation', [
+            'arguments' => [
+                'label' => [
+                    $content,
+                ],
+            ],
+        ]);
+
+        // Override final label (with translated link) as well
+        // as it will be used as default value if no translation is provided
+        $translatedLabel = vsprintf($label, [$content]);
+        $renderable->setLabel($translatedLabel);
+
+        // Reset linkText and pageUid properties in order
+        // to avoid additional link rendering in template
+        $renderable->setProperty('linkText', null);
+        $renderable->setProperty('pageUid', null);
+
+        // Set fallback value to original property values
+        // to allow other hooks making use of these ones
+        $renderable->setProperty('_label', $label);
+        $renderable->setProperty('_linkText', $translatedLinkText);
+        $renderable->setProperty('_pageUid', $pageUid);
+    }
+
+    /**
+     * Translate form element property.
+     *
+     * @param RootRenderableInterface $renderable
+     * @param string $property
+     * @param FormRuntime $formRuntime
+     * @return string
+     */
+    protected function translate(RootRenderableInterface $renderable, string $property, FormRuntime $formRuntime): string
+    {
+        return (string) TranslationService::getInstance()->translateFormElementValue($renderable, [$property], $formRuntime);
+    }
+
+    /**
+     * Build typolink from given page UID and additional configuration.
+     *
+     * @param $linkText
+     * @param int $pageUid
+     * @param array $additionalAttributes
+     * @return string
+     */
+    protected function buildLinkFromPageUid(string $linkText, int $pageUid, array $additionalAttributes = []): string
+    {
+        if (!$pageUid) {
+            return $linkText;
+        }
+
+        // Build typolink configuration from pageUid and additional attributes:
+        // As the pageUid is a necessary part of the parameter configuration,
+        // it cannot be overridden by $additionalAttributes. However one can
+        // provide additional parameter configuration by making use of the
+        // "parameter" key. This way one can disable the default link target
+        // behaviour which falls back to "_blank" by providing an empty
+        // value for the configuration key "parameter" or just setting any
+        // different parameter values according to the TypoScript reference.
+        $parameter = $pageUid . ' ';
+        if (array_key_exists('parameter', $additionalAttributes)) {
+            $parameter .= (string) $additionalAttributes['parameter'];
+        } else {
+            $parameter .= '_blank';
+        }
+        $configuration = [
+            'typolink.' => [
+                'parameter' => trim($parameter),
+            ],
+        ];
+        if ($additionalAttributes) {
+            unset($additionalAttributes['parameter']);
+            ArrayUtility::mergeRecursiveWithOverrule($configuration['typolink.'], $additionalAttributes);
+        }
+
+        $contentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $contentObject->start([], '');
+        $link = $contentObject->stdWrap($linkText, $configuration);
+
+        return $link;
+    }
+
+    /**
+     * Check whether the given string needs character substitution.
+     *
+     * This method checks whether a given string contains substitution characters (%) which will be used
+     * for character substitution using the `printf()` function. Substitution characters can be escaped
+     * by an additional character (%%) and will be excluded from the check.
+     *
+     * @param string $value String to test for the need of character substitution
+     * @return bool `true` if character substitution is needed, `false` otherwise
+     * @see printf()
+     */
+    protected static function needsCharacterSubstitution(string $value): bool
+    {
+        $filteredValue = $value;
+        do {
+            $filteredValue = str_replace('%%', '', $filteredValue);
+        } while(strpos($filteredValue, '%%') !== false);
+        return strpos($filteredValue, '%') !== false;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -12,10 +12,58 @@ configuration to your TypoScript template.
 
 ## Usage
 
-Open the TYPO3 form editor and create a new form/ open an existing one. Add
+Open the TYPO3 form editor and create a new form/open an existing one. Add
 a new element to your form. The modal will list the new custom form element
 "Linked checkbox". Provide a label for the checkbox and select a page you
 want to link to. Furthermore, you have to set a link text.
+
+### Combination of label and link
+
+The default label consists of the label itself, followed by a link to the
+specified page with the given link text. In case you want to use label and
+link together, just define the link position inside your label with a simple
+character substitution.
+
+Example:
+
+* Label: `I accept the %s.`
+* Link text: `terms and conditions`
+* Output: `I accept the <a href="/privacy-policy" target="_blank">terms and conditions</a>.`
+
+#### Link configuration
+
+You can provide additional link configuration which will be used when
+generating the link within the label. Note that this can only be defined
+in the appropriate `.form.yaml` file but not in the Backend module.
+
+```yaml
+type: LinkedCheckbox
+idenfitier: privacy-policy
+label: 'I accept the %s.'
+properties:
+  pageUid: '67'
+  linkText: 'terms and conditions'
+
+renderingOptions:
+  linkConfiguration:
+    # Additional typolink configuration can be inserted here, e.g.:
+    no_cache: 1
+```
+
+For a full list of available configuration take a look at the
+[TypoScript reference](https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/Functions/Typolink.html).
+
+#### Override default link target
+
+By default, the link target is set to `_blank`. If you want to override it,
+just define a custom link configuration `parameter` – either an empty string
+or a custom target/additional parameter configuration:
+
+```yaml
+renderingOptions:
+  linkConfiguration:
+    parameter: ''
+```
 
 ## Possible improvements or changes
 

--- a/Resources/Private/Frontend/Partials/LinkedCheckbox.html
+++ b/Resources/Private/Frontend/Partials/LinkedCheckbox.html
@@ -11,7 +11,7 @@
                         errorClass="{element.properties.elementErrorClassAttribute}"
                         additionalAttributes="{formvh:translateElementProperty(element: element, property: 'fluidAdditionalAttributes')}"
                 />
-                <span>{formvh:translateElementProperty(element: element, property: 'label')} <f:link.typolink parameter="{element.properties.pageUid}" target="_blank">{formvh:translateElementProperty(element: element, property: 'linkText')}</f:link.typolink> <f:if condition="{element.required}"> <f:render partial="Field/Required" /></f:if></span>
+                <span>{formvh:translateElementProperty(element: element, property: 'label') -> f:format.raw()} <f:link.typolink parameter="{element.properties.pageUid}" target="_blank">{formvh:translateElementProperty(element: element, property: 'linkText')}</f:link.typolink><f:if condition="{element.required}"> <f:render partial="Field/Required" /></f:if></span>
             </label>
         </div>
     </f:render>

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
             "name": "Björn Jacob TRITUM GmbH",
             "email": "bjoern.jacob@tritum.de"
         }
-    ]
+    ],
+    "autoload": {
+        "psr-4": {
+            "TRITUM\\FormElementLinkedCheckbox\\": "Classes/"
+        }
+    }
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -13,4 +13,7 @@ call_user_func(function () {
             }
         '));
     }
+
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['beforeRendering'][1571076908]
+        = \TRITUM\FormElementLinkedCheckbox\Hooks\FormElementLinkResolverHook::class;
 });


### PR DESCRIPTION
This commit introduces the possibility to insert the link text of a linked checkbox within the elements' label. In order to make use of this feature, the insert position for the checkbox link needs to be provided for the label.

Example:

```
type: LinkedCheckbox
identifier: linkedcheckbox-1
label: 'I accept the %s.'
properties:
  pageUid: '67'
  linkText: 'terms and conditions'
```

This will result in the following label:

```
<label>
  I accept the
  <a href="/index.php?id=67" target="_blank">terms and conditions</a>.
</label>
```

Additionally, one can provide custom typolink configuration which will be passed to the ContentObjectRenderer when building the link:

```
renderingOptions:
  linkConfiguration:
    # add custom configuration here
    no_cache: 1
```

To override the default link target, one can provide an empty value for the configuration key `renderingOptions.linkConfiguration.parameter`:

```
renderingOptions:
  linkConfiguration:
    # this will unset the default link target (_blank)
    parameter: ''
```

Related: #5