### PR TITLE
[TASK] Use `Typo3Version` class to check against current major version

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -14,8 +14,8 @@ call_user_func(function () {
         '));
     }
 
-    $branch = explode('.', TYPO3_branch);
-    if ($branch[0] === '10') {
+    $typo3Version = new \TYPO3\CMS\Core\Information\Typo3Version();
+    if ($typo3Version->getMajorVersion() === 10) {
         // load additional YAML configuration to load translation files differently for T3 v10
         if (TYPO3_MODE === 'BE') {
             \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(trim('


### PR DESCRIPTION
The class `Typo3Version` should be used to compare current TYPO3 version against a required version pattern. This was introduced with https://review.typo3.org/c/Packages/TYPO3.CMS/+/62740 (master aka 10.4) and https://review.typo3.org/c/Packages/TYPO3.CMS/+/64028 (9.5) respectively.