### PR TITLE
[TASK] Add compatibility with TYPO3 v11

### DIFF
--- a/Classes/Configuration/Extension.php
+++ b/Classes/Configuration/Extension.php
@@ -26,7 +26,6 @@ namespace TRITUM\FormElementLinkedCheckbox\Configuration;
 use TRITUM\FormElementLinkedCheckbox\Hooks\FormElementLinkResolverHook;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Extension
@@ -40,12 +39,6 @@ final class Extension
 
     public static function addTypoScriptSetup(): void
     {
-        // TypoScript setup at module.tx_form is only necessary in Backend context,
-        // therefore the following code must not be executed if we're in Frontend.
-        if (self::isEnvironmentInFrontendMode()) {
-            return;
-        }
-
         ExtensionManagementUtility::addTypoScriptSetup(trim('
             module.tx_form {
                 settings {
@@ -74,10 +67,5 @@ final class Extension
     public static function registerHooks(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['beforeRendering'][1571076908] = FormElementLinkResolverHook::class;
-    }
-
-    private static function isEnvironmentInFrontendMode(): bool
-    {
-        return isset($GLOBALS['TSFE']) && $GLOBALS['TSFE'] instanceof TypoScriptFrontendController;
     }
 }

--- a/Classes/Configuration/Extension.php
+++ b/Classes/Configuration/Extension.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "form_element_linked_checkbox".
+ *
+ * Copyright (C) 2021 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace TRITUM\FormElementLinkedCheckbox\Configuration;
+
+use TRITUM\FormElementLinkedCheckbox\Hooks\FormElementLinkResolverHook;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+/**
+ * Extension
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+final class Extension
+{
+    public const KEY = 'form_element_linked_checkbox';
+
+    public static function addTypoScriptSetup(): void
+    {
+        // TypoScript setup at module.tx_form is only necessary in Backend context,
+        // therefore the following code must not be executed if we're in Frontend.
+        if (self::isEnvironmentInFrontendMode()) {
+            return;
+        }
+
+        ExtensionManagementUtility::addTypoScriptSetup(trim('
+            module.tx_form {
+                settings {
+                    yamlConfigurations {
+                        1505042806 = EXT:form_element_linked_checkbox/Configuration/Yaml/FormSetup.yaml
+                    }
+                }
+            }
+        '));
+
+        // load additional YAML configuration to load translation files differently for T3 v10
+        $typo3Version = new Typo3Version();
+        if ($typo3Version->getMajorVersion() >= 10) {
+            ExtensionManagementUtility::addTypoScriptSetup(trim('
+                module.tx_form {
+                    settings {
+                        yamlConfigurations {
+                            1587917063 = EXT:form_element_linked_checkbox/Configuration/Yaml/FormSetupV10.yaml
+                        }
+                    }
+                }
+            '));
+        }
+    }
+
+    public static function registerHooks(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['beforeRendering'][1571076908] = FormElementLinkResolverHook::class;
+    }
+
+    private static function isEnvironmentInFrontendMode(): bool
+    {
+        return isset($GLOBALS['TSFE']) && $GLOBALS['TSFE'] instanceof TypoScriptFrontendController;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,9 @@
     "description": "",
     "type": "typo3-cms-extension",
     "require": {
-        "typo3/cms-core": "^9.5.25 || ^10.4.14",
-        "typo3/cms-form": "^9.5.25 || ^10.4.14"
+        "typo3/cms-core": "^9.5.25 || ^10.4.14 || 11.*.*@dev",
+        "typo3/cms-form": "^9.5.25 || ^10.4.14 || 11.*.*@dev",
+        "typo3/cms-frontend": "^9.5.25 || ^10.4.14 || 11.*.*@dev"
     },
     "license": "GPL-2.0-or-later",
     "authors": [

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF['form_element_linked_checkbox'] = [
     'version' => '2.1.2',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5.25-10.4.99',
+            'typo3' => '9.5.25-11.99.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,35 +1,5 @@
 <?php
 defined('TYPO3_MODE') or die();
 
-call_user_func(function () {
-    if (TYPO3_MODE === 'BE') {
-        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(trim('
-            module.tx_form {
-                settings {
-                    yamlConfigurations {
-                        1505042806 = EXT:form_element_linked_checkbox/Configuration/Yaml/FormSetup.yaml
-                    }
-                }
-            }
-        '));
-    }
-
-    $typo3Version = new \TYPO3\CMS\Core\Information\Typo3Version();
-    if ($typo3Version->getMajorVersion() === 10) {
-        // load additional YAML configuration to load translation files differently for T3 v10
-        if (TYPO3_MODE === 'BE') {
-            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(trim('
-            module.tx_form {
-                settings {
-                    yamlConfigurations {
-                        1587917063 = EXT:form_element_linked_checkbox/Configuration/Yaml/FormSetupV10.yaml
-                    }
-                }
-            }
-        '));
-        }
-    }
-
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['beforeRendering'][1571076908]
-        = \TRITUM\FormElementLinkedCheckbox\Hooks\FormElementLinkResolverHook::class;
-});
+\TRITUM\FormElementLinkedCheckbox\Configuration\Extension::addTypoScriptSetup();
+\TRITUM\FormElementLinkedCheckbox\Configuration\Extension::registerHooks();


### PR DESCRIPTION
This PR adds compatibility with TYPO3 v11. The following changes were made:

* Extend version requirements in `composer.json` and `ext_emconf.php`
* Add missing dependency to `typo3/cms-frontend`
* Avoid usage of `TYPO3_MODE` constant ~~– use check for `$GLOBALS['TSFE']` instead~~ (see [deprecation notice](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/11.0/Deprecation-92947-DeprecateTYPO3_MODEAndTYPO3_REQUESTTYPEConstants.html))
* Add new class `TRITUM\FormElementLinkedCheckbox\Configuration\Extension` ~~for better handling of TSFE check in combination with registration of static TypoScript~~
* Assure `Configuration/Yaml/FormSetupV10.yaml` file is registered for TYPO3 >= v10