### PR TITLE
[FEATURE] Add support for multiple links in checkbox label

### DIFF
--- a/Configuration/Yaml/FormSetup.yaml
+++ b/Configuration/Yaml/FormSetup.yaml
@@ -22,6 +22,7 @@ TYPO3:
                   properties:
                     pageUid: ''
                     linkText: 'formEditor.elements.LinkedCheckbox.editor.linkText.predefinedDefaults'
+                    additionalLinks: { }
                 # add new field which allows selection of a page (= link target)
                 editors:
                   300:
@@ -44,6 +45,22 @@ TYPO3:
                     propertyPath: 'properties.linkText'
                     propertyValidators:
                       10: 'NotEmpty'
+                  500:
+                    identifier: 'additionalLinks'
+                    templateName: 'Inspector-PropertyGridEditor'
+                    label: 'formEditor.elements.LinkedCheckbox.editor.additionalLinks.label'
+                    propertyPath: 'properties.additionalLinks'
+                    fieldExplanationText: 'formEditor.elements.LinkedCheckbox.editor.additionalLinks.fieldExplanationText'
+                    isSortable: true
+                    enableAddRow: true
+                    enableDeleteRow: true
+                    useLabelAsFallbackValue: false
+                    gridColumns:
+                      - name: label
+                        title: 'formEditor.elements.LinkedCheckbox.editor.additionalLinks.gridColumns.linkText.title'
+                      - name: value
+                        title: 'formEditor.elements.LinkedCheckbox.editor.additionalLinks.gridColumns.pageUid.title'
+
 
           formEditor:
             # does not work in v10 but does no harm and can be kept for backward compatibility

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Example:
 
 * Label: `I accept the `
 * Link text: `terms and conditions.`
-* Output: `I accept the <a href="/privacy-policy" target="_blank">terms and conditions.</a>`
+* Output: `I accept the <a href="/terms" target="_blank">terms and conditions.</a>`
 
 If want to use the link inside your label, define the link position
 in the label with a character substitution. We highly **recommend** this way.
@@ -37,7 +37,20 @@ Example:
 
 * Label: `I have read the %s and accept them.`
 * Link text: `terms and conditions`
-* Output: `I have read the <a href="/privacy-policy" target="_blank">terms and conditions</a> and accept them.`
+* Output: `I have read the <a href="/terms" target="_blank">terms and conditions</a> and accept them.`
+
+You can also use more than one link in the checkbox label. For this, just
+use the field `additionalLinks` and provide a combination of Page UID and
+link text.
+
+Example:
+
+* Label: `I have read the %s and %s and accept them.`
+* Link text: `terms and conditions`
+* Additional links:
+  - `privacy policy`
+* Output: `I have read the <a href="/terms" target="_blank">terms and conditions</a> and <a href="/privacy-policy" target="_blank">privacy policy</a> and accept them.`
+
 
 > Note: Either way, you have to overwrite your email templates in order to correctly output the data. Check the section below regarding email templates.
 
@@ -45,15 +58,18 @@ Example:
 
 You can provide additional link configuration which will be used when
 generating the link within the label. Note that this can only be defined
-in the appropriate `.form.yaml` file but not in the form editor.
+in the appropriate `.form.yaml` file but not in the form editor and
+applies to all generated links.
 
 ```yaml
 type: LinkedCheckbox
-identifier: privacy-policy
-label: 'I accept the %s.'
+identifier: consent
+label: 'I accept the %s and %s.'
 properties:
   pageUid: '67'
   linkText: 'terms and conditions'
+  additionalLinks:
+    83: 'privacy policy'
 
 renderingOptions:
   linkConfiguration:

--- a/Resources/Private/Language/Database.xlf
+++ b/Resources/Private/Language/Database.xlf
@@ -15,6 +15,18 @@
 			<trans-unit id="formEditor.elements.LinkedCheckbox.editor.linkText.predefinedDefaults" resname="formEditor.elements.LinkedCheckbox.editor.linkText.predefinedDefaults" xml:space="preserve">
 				<source>more...</source>
 			</trans-unit>
+			<trans-unit id="formEditor.elements.LinkedCheckbox.editor.additionalLinks.label" resname="formEditor.elements.LinkedCheckbox.editor.additionalLinks.label" xml:space="preserve">
+				<source>Additional links</source>
+			</trans-unit>
+			<trans-unit id="formEditor.elements.LinkedCheckbox.editor.additionalLinks.fieldExplanationText" resname="formEditor.elements.LinkedCheckbox.editor.additionalLinks.fieldExplanationText" xml:space="preserve">
+				<source>You can add more links here that should replace placeholders in the checkbox label.</source>
+			</trans-unit>
+			<trans-unit id="formEditor.elements.LinkedCheckbox.editor.additionalLinks.gridColumns.linkText.title" resname="formEditor.elements.LinkedCheckbox.editor.additionalLinks.gridColumns.linkText.title" xml:space="preserve">
+				<source>Link text</source>
+			</trans-unit>
+			<trans-unit id="formEditor.elements.LinkedCheckbox.editor.additionalLinks.gridColumns.pageUid.title" resname="formEditor.elements.LinkedCheckbox.editor.additionalLinks.gridColumns.pageUid.title" xml:space="preserve">
+				<source>Page</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
This PR adds additional support for more than one link in labels of `LinkedCheckbox` elements.

## Configuration

Additional links are configured either via Backend UI oder directly inside the YAML configuration file.

### Backend

A new configuration element "Additional links" of type `PropertyGridEditor` is added. Each row represents an additional link (next to the default link that is defined via properties `pageUid` and `linkText`).

![Bildschirmfoto 2021-09-25 um 15 34 09](https://user-images.githubusercontent.com/16313625/134773371-a17daff5-ae10-4236-96fc-16c8fd7b0a44.png)

### YAML

```yaml
identifier: terms-consent
type: LinkedCheckbox
label: 'I agree to the %s and %s.'
properties:
  pageUid: '6'
  linkText: 'participation terms'
  additionalLinks:
    # <page uid>: <link text>
    7: 'privacy policy'
```

## Link resolving

The hook class `FormElementLinkResolverHook` has been extended to support single-link configuration and array-link configuration. Both link configurations will be resolved and then merged together as one single array that is passed as translation argument to the `label` property.

## Support

Supports all currently supported TYPO3 versions. Additional support for TYPO3 v11 is granted and tested in combination with #30.