### PR TITLE
[BUGFIX] Assure character substitution in all contexts

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -30,6 +30,6 @@ call_user_func(function () {
         }
     }
 
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['beforeRendering'][1571076908]
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['afterFormStateInitialized'][1571076908]
         = \TRITUM\FormElementLinkedCheckbox\Hooks\FormElementLinkResolverHook::class;
 });


### PR DESCRIPTION
Character substitution is currently only processed before rendering takes place. This leads to the fact that **links are not always processed**, e.g. after the form was submitted and finishers are invoked.

In order to assure character substitution is always processed, **another hook is now used** to trigger the `FormElementLinkResolverHook` class. We now use the hook `$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['afterFormStateInitialized']` which is always called from [`FormRuntime::triggerAfterFormStateInitialized`](https://github.com/TYPO3/typo3/blob/cdf316db8df614b4f0dc843fd6df966359a0884d/typo3/sysext/form/Classes/Domain/Runtime/FormRuntime.php#L203).

Triggering the **previously used hook** now triggers a **deprecation notice** in order to avoid breaking other solutions that are based on it.

The legacy hook should be removed when bumping a new major version.

Resolves: #23
Tested by: @iamwebrocker (see https://github.com/tritum/form_element_linked_checkbox/issues/23#issuecomment-931114306)