### PR TITLE
[BUGFIX] Assure TYPO3 v9 compatibility for updated hook

### DIFF
--- a/Classes/Hooks/FormElementLinkResolverHook.php
+++ b/Classes/Hooks/FormElementLinkResolverHook.php
@@ -44,10 +44,10 @@ class FormElementLinkResolverHook implements AfterFormStateInitializedInterface
      */
     public function afterFormStateInitialized(FormRuntime $formRuntime): void
     {
-        $elements = $formRuntime->getFormDefinition()->getElements();
+        $renderables = $formRuntime->getFormDefinition()->getRenderablesRecursively();
 
-        foreach ($elements as $element) {
-            $this->processCharacterSubstitution($formRuntime, $element);
+        foreach ($renderables as $renderable) {
+            $this->processCharacterSubstitution($formRuntime, $renderable);
         }
     }
 


### PR DESCRIPTION
This PR assures that the updated `FormElementLinkResolverHook` (updated with #32) can be used with TYPO3 v9 as well.

Background: `FormDefinition::getElements()` is available since TYPO3 10.2.0 only (see typo3/typo3@0f4ba2e). Therefore, `FormDefinition::getRenderablesRecursively()` is now used.