### PR TITLE
[BUGFIX] Avoid output of link text after successful character substitution

### DIFF
--- a/Classes/Hooks/FormElementLinkResolverHook.php
+++ b/Classes/Hooks/FormElementLinkResolverHook.php
@@ -126,6 +126,7 @@ class FormElementLinkResolverHook implements AfterFormStateInitializedInterface
         $renderable->setProperty('_label', $label);
         $renderable->setProperty('_linkText', $translatedLinkText);
         $renderable->setProperty('_pageUid', $pageUid);
+        $renderable->setProperty('_linksProcessed', true);
     }
 
     /**

--- a/Resources/Private/Frontend/Partials/LinkedCheckbox.html
+++ b/Resources/Private/Frontend/Partials/LinkedCheckbox.html
@@ -11,7 +11,7 @@
                         errorClass="{element.properties.elementErrorClassAttribute}"
                         additionalAttributes="{formvh:translateElementProperty(element: element, property: 'fluidAdditionalAttributes')}"
                 />
-                <span>{formvh:translateElementProperty(element: element, property: 'label') -> f:format.raw()} <f:link.typolink parameter="{element.properties.pageUid}" target="_blank">{formvh:translateElementProperty(element: element, property: 'linkText')}</f:link.typolink><f:if condition="{element.required}"> <f:render partial="Field/Required" /></f:if></span>
+                <span>{formvh:translateElementProperty(element: element, property: 'label') -> f:format.raw()} <f:if condition="!{element.properties._linksProcessed}"><f:link.typolink parameter="{element.properties.pageUid}" target="_blank">{formvh:translateElementProperty(element: element, property: 'linkText')}</f:link.typolink></f:if><f:if condition="{element.required}"> <f:render partial="Field/Required" /></f:if></span>
             </label>
         </div>
     </f:render>


### PR DESCRIPTION
This PR assures that links are not rendered multiple times if character substitution was already processed.

Resolves: #24