### PR TITLE
[TASK] Migrate to use ESM modules for TYPO3 v12

### DIFF
--- a/Classes/Configuration/Extension.php
+++ b/Classes/Configuration/Extension.php
@@ -24,7 +24,9 @@ declare(strict_types=1);
 namespace TRITUM\FormElementLinkedCheckbox\Configuration;
 
 use TRITUM\FormElementLinkedCheckbox\Hooks\FormElementLinkResolverHook;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Extension
@@ -48,6 +50,18 @@ final class Extension
                 }
             }
         '));
+
+        if ((GeneralUtility::makeInstance(Typo3Version::class))->getMajorVersion() === 11) {
+            ExtensionManagementUtility::addTypoScriptSetup(trim('
+                module.tx_form {
+                    settings {
+                        yamlConfigurations {
+                            1690355809 = EXT:form_element_linked_checkbox/Configuration/Yaml/FormSetupV11.yaml
+                        }
+                    }
+                }
+            '));
+        }
     }
 
     public static function registerHooks(): void

--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'dependencies' => [
+        'core',
+        'form',
+    ],
+    'imports' => [
+        '@tritum/form-element-linked-checkbox/' => 'EXT:form_element_linked_checkbox/Resources/Public/ESM/',
+    ],
+];

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -5,3 +5,12 @@ plugin.tx_form {
     }
   }
 }
+[typo3.branch == "11.5"]
+  plugin.tx_form {
+    settings {
+      yamlConfigurations {
+        1690355809 = EXT:form_element_linked_checkbox/Configuration/Yaml/FormSetupV11.yaml
+      }
+    }
+  }
+[global]

--- a/Configuration/Yaml/FormSetup.yaml
+++ b/Configuration/Yaml/FormSetup.yaml
@@ -76,8 +76,8 @@ TYPO3:
           formEditor:
             translationFiles:
               1687159009: 'EXT:form_element_linked_checkbox/Resources/Private/Language/Database.xlf'
-            dynamicRequireJsModules:
+            dynamicJavaScriptModules:
               additionalViewModelModules:
-                1687159242: 'TYPO3/CMS/FormElementLinkedCheckbox/Backend/FormEditor/ViewModel'
+                1687159242: '@tritum/form-element-linked-checkbox/backend/form-editor/view-model.js'
             formEditorPartials:
               FormElement-LinkedCheckbox: 'Stage/SimpleTemplate'

--- a/Configuration/Yaml/FormSetupV11.yaml
+++ b/Configuration/Yaml/FormSetupV11.yaml
@@ -1,0 +1,9 @@
+TYPO3:
+  CMS:
+    Form:
+      prototypes:
+        standard:
+          formEditor:
+            dynamicRequireJsModules:
+              additionalViewModelModules:
+                1687159242: 'TYPO3/CMS/FormElementLinkedCheckbox/Backend/FormEditor/ViewModel'

--- a/Resources/Public/ESM/backend/form-editor/view-model.js
+++ b/Resources/Public/ESM/backend/form-editor/view-model.js
@@ -1,0 +1,18 @@
+/**
+ * Module: @tritum/form-element-linked-checkbox/backend/form-editor/view-model.js
+ */
+
+function subscribeEvents(formEditorApp) {
+    formEditorApp.getPublisherSubscriber().subscribe('view/stage/abstract/render/template/perform',(
+        topic,
+        [formElement, template]
+    ) => {
+        if (formElement.get('type') === 'LinkedCheckbox') {
+            formEditor.getViewModel().getStage().renderCheckboxTemplate(formElement, template);
+        }
+    });
+}
+
+export function bootstrap(formEditorApp) {
+    subscribeEvents(formEditorApp);
+}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"php": "^7.4 || ^8.0",
 		"symfony/polyfill-php80": "^1.15",
 		"typo3/cms-core": "^11.5.0 || ^12.4.0",
-		"typo3/cms-form": "^11.5.0 || ^12.4.0",
+		"typo3/cms-form": "^11.5.0 || ^12.4.5",
 		"typo3/cms-frontend": "^11.5.0 || ^12.4.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
Requires at least 12.4.5 for TYPO3 v12 as a bug needed to be fixed first:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/80174