### PR TITLE
Fix variant substitution by using `beforeRendering` hook

### DIFF
--- a/Classes/Configuration/Extension.php
+++ b/Classes/Configuration/Extension.php
@@ -52,6 +52,6 @@ final class Extension
 
     public static function registerHooks(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['afterInitializeCurrentPage'][1571076908] = FormElementLinkResolverHook::class;
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['beforeRendering'][1571076908] = FormElementLinkResolverHook::class;
     }
 }

--- a/Classes/Hooks/FormElementLinkResolverHook.php
+++ b/Classes/Hooks/FormElementLinkResolverHook.php
@@ -46,17 +46,11 @@ final class FormElementLinkResolverHook
     private $formRuntime;
 
     /**
-     * Resolve link in label of form elements with type LinkedCheckbox.
+     * Resolve link in label for form elements with type LinkedCheckbox
      */
-    public function afterInitializeCurrentPage(FormRuntime $formRuntime, ?Page $currentPage): ?Page
+    public function beforeRendering(FormRuntime $formRuntime, RootRenderableInterface $renderable)
     {
-        $renderables = $formRuntime->getFormDefinition()->getRenderablesRecursively();
-
-        foreach ($renderables as $renderable) {
-            $this->processCharacterSubstitution($formRuntime, $renderable);
-        }
-
-        return $currentPage;
+        $this->processCharacterSubstitution($formRuntime, $renderable);
     }
 
     /**


### PR DESCRIPTION
Currently character substitution with variants does not work properly, resulting in the unprocessed text being displayed in the form.
The reason why has already been mentioned in https://github.com/tritum/form_element_linked_checkbox/issues/61#issuecomment-1665720939, but tl;dr: Variants are processed before and after the `afterInitializeCurrentPage` hook, causing the text substitution to be overwritten with the unprocessed text.

Solution is to use the `beforeRendering` hook, which triggers after any call to `FormRuntime->processVariants`.

Fixes #61