### PR TITLE
[!!!][TASK] Allow TYPO3 v13, drop TYPO3 v11 support

### DIFF
--- a/Configuration/Sets/FormDoubleOptIn/config.yaml
+++ b/Configuration/Sets/FormDoubleOptIn/config.yaml
@@ -1,0 +1,4 @@
+name: tritum/form-element-linked-checkbox
+label: "Form: Linked checkbox element"
+dependencies:
+  - typo3/form

--- a/Configuration/Sets/FormDoubleOptIn/setup.typoscript
+++ b/Configuration/Sets/FormDoubleOptIn/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:form_element_linked_checkbox/Configuration/TypoScript/setup.typoscript'

--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ use this template.
 
 ## Preferred Installation
 
-1. Require the extension via composer.
-2. Add the static TypoScript configuration to your TypoScript template.
+#. Require the extension via composer.
+#. Add the site set `tritum/form-element-linked-checkbox` to the dependencies
+   of your site packages site set (TYPO3 v13 and above).
+#. Or add the static TypoScript configuration to your TypoScript template
+   (TYPO3 v12 and below).
 
 ## Customization
 

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
 	"require": {
 		"php": "^7.4 || ^8.0",
 		"symfony/polyfill-php80": "^1.15",
-		"typo3/cms-core": "^11.5.0 || ^12.4.0",
-		"typo3/cms-form": "^11.5.0 || ^12.4.0",
-		"typo3/cms-frontend": "^11.5.0 || ^12.4.0"
+		"typo3/cms-core": "^12.4.0 || ^13.4.0",
+		"typo3/cms-form": "^12.4.0 || ^13.4.0",
+		"typo3/cms-frontend": "^12.4.0 || ^13.4.0"
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^1.5",


### PR DESCRIPTION
Resolves https://github.com/tritum/form_element_linked_checkbox/issues/73

Other then https://github.com/tritum/form_element_linked_checkbox/pull/72 this PR also does the following:

* Introduce site sets as TypoScript providers